### PR TITLE
Debug configuration errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.2.0'
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0'
+    // SpringDoc OpenAPI (Swagger UI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/peter/tanxuannewapp/config/SecurityConfiguration.java
+++ b/src/main/java/com/peter/tanxuannewapp/config/SecurityConfiguration.java
@@ -66,7 +66,9 @@ public class SecurityConfiguration {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/v1/login", "/api/v1/register", "/api/v1/admin/login",
-                                "/api/v1/admin/register", "/api/v1/categories", "/storage/**")
+                                "/api/v1/admin/register", "/api/v1/categories", "/storage/**",
+                                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", 
+                                "/swagger-resources/**", "/webjars/**")
                         .permitAll()
                         .anyRequest().authenticated())
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,9 @@ peterBui.upload-file.base-uri=file:///D:/Workspace/Java-mvc/TanXuanNewApp/storag
 #validate file size upload
 peterBui.multipart.max-file-size=10MB
 peterBui.multipart.max-request-size=10MB
+
+# SpringDoc OpenAPI (Swagger) configuration
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.enabled=true
+springdoc.api-docs.enabled=true


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add SpringDoc OpenAPI dependency and configure Spring Security to fix 401 errors when accessing Swagger UI.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application was returning a 401 Unauthorized error when attempting to load the Swagger UI due to missing SpringDoc OpenAPI dependency, an incomplete Spring Security configuration that blocked Swagger paths, and a lack of specific SpringDoc properties. This PR addresses all three issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-c134c10e-a857-4f4b-a90c-419992e6b53d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c134c10e-a857-4f4b-a90c-419992e6b53d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>